### PR TITLE
adding prerequisites installation commands for macOS.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,15 @@ Debian / Ubuntu:
 ```
 sudo apt-get install libgraph-easy-perl
 ```
+
+macOS
+
+```
+brew install docker
+# start docker
+brew install whalebrew
+whalebrew install tsub/graph-easy
+```
 ## Install
 
 ### From source


### PR DESCRIPTION
Add commands about how to install easy graph on macOS through Docker.

Credit to: https://stackoverflow.com/a/55403011/6163756